### PR TITLE
do js editor as 5px margin instead of auto

### DIFF
--- a/local-app/napkin-ui.css
+++ b/local-app/napkin-ui.css
@@ -59,7 +59,7 @@ body {
   min-width:520px;
   max-width:900px;
   min-height:60px;
-  margin:auto;
+  margin:5px;
   display:block;
   border-bottom:solid 5px #ddd;
   background-color:#555;


### PR DESCRIPTION
auto causes some visual problems and an uneeded overflow scrollbar
-is much simpler for now to let it hang to the left by default
